### PR TITLE
feat: add scientific journal article tracker

### DIFF
--- a/.github/workflows/fetch-articles.yml
+++ b/.github/workflows/fetch-articles.yml
@@ -1,0 +1,37 @@
+name: Fetch Journal Articles
+
+on:
+  schedule:
+    # Run daily at 12:00 PM UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  fetch-articles:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: Fetch articles from RSS feeds
+        run: ruby scripts/fetch_articles.rb
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add _data/articles.yml
+          
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update journal articles [skip ci]"
+            git push
+          fi

--- a/JOURNAL_TRACKER.md
+++ b/JOURNAL_TRACKER.md
@@ -1,0 +1,105 @@
+# Journal Article Tracker
+
+A Feedly-like page to track and display articles from your favorite scientific journals. Articles are automatically fetched from RSS feeds and updated daily via GitHub Actions.
+
+## How It Works
+
+### 1. **Configuration** (`_data/journals.yml`)
+Defines the list of journals to track, including:
+- Journal name
+- Journal website URL
+- RSS feed URL
+- Display color
+
+Add or remove journals by editing this file.
+
+### 2. **RSS Feed Fetcher** (`scripts/fetch_articles.rb`)
+Ruby script that:
+- Reads the journals configuration
+- Fetches articles from each journal's RSS feed
+- Extracts title, authors, publication date, and description
+- Saves articles to `_data/articles.yml` (max 20 articles per journal)
+- Sorts articles by date (newest first)
+
+### 3. **GitHub Actions Workflow** (`.github/workflows/fetch-articles.yml`)
+Automated CI/CD pipeline that:
+- **Runs daily at 12:00 PM UTC** (customizable via cron syntax)
+- Can also be triggered manually via GitHub's UI
+- Runs the fetch script
+- Commits updated articles back to the repository
+- Automatically triggers Jekyll to rebuild your site
+
+### 4. **Display Page** (`_pages/journal-tracker.md`)
+Jekyll page that:
+- Renders articles grouped by journal
+- Shows title, authors, publication date
+- Links to the full article
+- Updates automatically when articles are fetched
+
+## Setup Instructions
+
+### First Time Setup
+1. Push this code to your GitHub repository
+2. Ensure GitHub Actions is enabled (Settings → Actions)
+3. The workflow will run automatically on schedule OR you can manually trigger it:
+   - Go to Actions → "Fetch Journal Articles" → Run workflow
+
+### To Test Manually
+On GitHub:
+1. Go to **Actions** tab
+2. Select **"Fetch Journal Articles"** workflow
+3. Click **"Run workflow"** button
+4. Wait for it to complete and check for commits
+
+### To Add/Remove Journals
+Edit `_data/journals.yml`:
+```yaml
+- name: "Journal Name"
+  url: "https://journal-website.com"
+  feed: "https://journal-website.com/rss.xml"
+  color: "#FF6B6B"
+```
+
+Find RSS feed URLs by looking for RSS/Atom links on journal homepages.
+
+### To Change Update Schedule
+Edit `.github/workflows/fetch-articles.yml`, line with cron:
+```yaml
+- cron: '0 12 * * *'  # Daily at 12:00 PM UTC
+```
+
+[Cron syntax reference](https://crontab.guru/)
+
+## File Structure
+```
+.github/
+└── workflows/
+    └── fetch-articles.yml      # GitHub Actions workflow
+_data/
+├── journals.yml                # Journal configuration
+└── articles.yml                # Generated article data
+_pages/
+└── journal-tracker.md          # Display page
+scripts/
+└── fetch_articles.rb           # RSS fetching script
+```
+
+## Troubleshooting
+
+### Articles not updating?
+1. Check **Actions** tab for workflow errors
+2. Verify RSS feed URLs are correct and accessible
+3. Try running workflow manually to see error messages
+
+### Missing articles?
+- Some journals may have feeds that don't include all metadata
+- The script extracts up to 3 authors per article
+- Articles are limited to 20 most recent from each journal
+
+### Page shows "Articles are loading"?
+- The workflow hasn't run yet
+- Manually trigger it via Actions tab
+- Wait for the workflow to complete
+
+## Dependencies
+The GitHub Actions workflow automatically installs Ruby and required gems. No additional setup needed on your end.

--- a/_data/articles.yml
+++ b/_data/articles.yml
@@ -1,0 +1,14 @@
+---
+last_updated: "2026-05-29 18:09:50 UTC"
+articles:
+  Cell: []
+  "Cell Reports": []
+  "Current Biology": []
+  eLife: []
+  Nature: []
+  "Nature Communications": []
+  "Nature Human Behaviour": []
+  "Nature Neuroscience": []
+  Neuron: []
+  Science: []
+  "Science Advances": []

--- a/_data/journals.yml
+++ b/_data/journals.yml
@@ -1,0 +1,55 @@
+journals:
+  - name: "Nature"
+    url: "https://www.nature.com"
+    feed: "https://www.nature.com/nature.rss"
+    color: "#003366"
+
+  - name: "Science"
+    url: "https://www.science.org"
+    feed: "https://www.sciencemag.org/rss/current.xml"
+    color: "#1F4E7C"
+
+  - name: "Cell"
+    url: "https://www.cell.com"
+    feed: "https://www.cell.com/cell/current.rss"
+    color: "#0066CC"
+
+  - name: "Neuron"
+    url: "https://www.cell.com/neuron"
+    feed: "https://www.cell.com/neuron/current.rss"
+    color: "#FF6B6B"
+
+  - name: "Nature Neuroscience"
+    url: "https://www.nature.com/neuro"
+    feed: "https://www.nature.com/neuro.rss"
+    color: "#8B00FF"
+
+  - name: "Current Biology"
+    url: "https://www.cell.com/current-biology"
+    feed: "https://www.cell.com/current-biology/current.rss"
+    color: "#00A86B"
+
+  - name: "Cell Reports"
+    url: "https://www.cell.com/cell-reports"
+    feed: "https://www.cell.com/cell-reports/current.rss"
+    color: "#FF8C00"
+
+  - name: "eLife"
+    url: "https://elifesciences.org"
+    feed: "https://elifesciences.org/rss/research.rss"
+    color: "#00A651"
+
+  - name: "Nature Communications"
+    url: "https://www.nature.com/ncomms"
+    feed: "https://www.nature.com/ncomms.rss"
+    color: "#E63946"
+
+  - name: "Nature Human Behaviour"
+    url: "https://www.nature.com/nathumbehav"
+    feed: "https://www.nature.com/nathumbehav.rss"
+    color: "#F77F00"
+
+  - name: "Science Advances"
+    url: "https://www.science.org/journal/sciadv"
+    feed: "https://advances.sciencemag.org/rss/current.xml"
+    color: "#06A77D"

--- a/_pages/journal-tracker.md
+++ b/_pages/journal-tracker.md
@@ -1,0 +1,162 @@
+---
+layout: single
+title: "Journal Article Tracker"
+permalink: /journal-tracker/
+author_profile: true
+read_time: false
+comments: false
+share: true
+---
+
+<style>
+  .journal-section {
+    margin-bottom: 3rem;
+    background: #f8f9fa;
+    padding: 2rem;
+    border-radius: 8px;
+    border-left: 4px solid #333;
+  }
+
+  .journal-section h2 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    color: #333;
+    font-size: 1.5rem;
+  }
+
+  .articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .article-card {
+    background: white;
+    border-radius: 6px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.3s, transform 0.3s;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .article-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+  }
+
+  .article-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem 0;
+    line-height: 1.4;
+  }
+
+  .article-title a {
+    color: #0066cc;
+    text-decoration: none;
+  }
+
+  .article-title a:hover {
+    text-decoration: underline;
+  }
+
+  .article-authors {
+    font-size: 0.9rem;
+    color: #666;
+    margin-bottom: 0.5rem;
+    font-style: italic;
+  }
+
+  .article-date {
+    font-size: 0.85rem;
+    color: #999;
+    margin-bottom: 1rem;
+  }
+
+  .article-description {
+    font-size: 0.9rem;
+    color: #555;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+    flex-grow: 1;
+  }
+
+  .article-link {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    background: #0066cc;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    transition: background 0.3s;
+  }
+
+  .article-link:hover {
+    background: #0052a3;
+  }
+
+  .last-updated {
+    text-align: center;
+    color: #999;
+    font-size: 0.9rem;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid #ddd;
+  }
+
+  .no-articles {
+    color: #999;
+    text-align: center;
+    padding: 2rem;
+    background: white;
+    border-radius: 6px;
+  }
+</style>
+
+## Latest Articles from Your Favorite Journals
+
+Track the latest research across your favorite scientific journals. Articles are fetched automatically and updated daily.
+
+{% if site.data.articles.articles %}
+  {% for journal_name in site.data.articles.articles %}
+    {% assign journal_articles = site.data.articles.articles[journal_name] %}
+    {% if journal_articles and journal_articles.size > 0 %}
+    <div class="journal-section">
+      <h2>{{ journal_name }} ({{ journal_articles.size }})</h2>
+      <div class="articles-grid">
+        {% for article in journal_articles %}
+        <div class="article-card">
+          <h3 class="article-title">
+            <a href="{{ article.link }}" target="_blank" rel="noopener noreferrer">
+              {{ article.title }}
+            </a>
+          </h3>
+          {% if article.authors and article.authors.size > 0 %}
+          <div class="article-authors">
+            {{ article.authors | join: ", " }}
+          </div>
+          {% endif %}
+          <div class="article-date">{{ article.published_date }}</div>
+          {% if article.description and article.description.size > 0 %}
+          <div class="article-description">{{ article.description | truncatewords: 30 }}</div>
+          {% endif %}
+          <a href="{{ article.link }}" target="_blank" rel="noopener noreferrer" class="article-link">
+            Read Article →
+          </a>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  {% endfor %}
+
+  <div class="last-updated">
+    <small>Last updated: {{ site.data.articles.last_updated }}</small>
+  </div>
+{% else %}
+  <div class="no-articles">
+    <p>Articles are loading... The GitHub Action will automatically fetch articles from all journals.</p>
+  </div>
+{% endif %}

--- a/scripts/fetch_articles.rb
+++ b/scripts/fetch_articles.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+require 'rss'
+require 'yaml'
+require 'open-uri'
+require 'time'
+
+# Load journals configuration
+journals_file = File.join(__dir__, '..', '_data', 'journals.yml')
+journals_config = YAML.load_file(journals_file)
+
+articles = {}
+
+journals_config['journals'].each do |journal|
+  journal_name = journal['name']
+  feed_url = journal['feed']
+  
+  begin
+    puts "Fetching articles from #{journal_name}..."
+    
+    # Fetch and parse RSS feed with timeout
+    feed_content = URI.open(feed_url, read_timeout: 30).read
+    feed = RSS::Parser.parse(feed_content)
+    
+    articles[journal_name] = []
+    
+    # Extract articles from feed (limit to 20 most recent)
+    feed.items.first(20).each do |item|
+      article = {
+        title: item.title&.strip || 'Untitled',
+        link: item.link || '',
+        published_date: item.pubDate ? item.pubDate.to_time.strftime('%Y-%m-%d') : Time.now.strftime('%Y-%m-%d'),
+        authors: extract_authors(item),
+        description: item.description&.strip || ''
+      }
+      
+      articles[journal_name] << article
+    end
+    
+    # Sort by date descending
+    articles[journal_name].sort_by! { |a| a[:published_date] }.reverse!
+    
+  rescue => e
+    puts "ERROR fetching #{journal_name}: #{e.message}"
+    articles[journal_name] = []
+  end
+end
+
+# Sort journals alphabetically and write to YAML
+sorted_articles = articles.sort.to_h
+
+output_file = File.join(__dir__, '..', '_data', 'articles.yml')
+File.write(output_file, {
+  'last_updated' => Time.now.strftime('%Y-%m-%d %H:%M:%S %Z'),
+  'articles' => sorted_articles
+}.to_yaml)
+
+puts "\n✓ Successfully fetched #{sorted_articles.sum { |_, a| a.length }} articles from #{sorted_articles.length} journals"
+puts "  Saved to #{output_file}"
+
+# Helper to extract authors from feed item
+def extract_authors(item)
+  authors = []
+  
+  # Try various author fields in order of preference
+  if item.respond_to?(:author) && item.author
+    authors << item.author
+  elsif item.respond_to?(:creator) && item.creator
+    authors << item.creator
+  elsif item.respond_to?(:authors) && item.authors
+    authors = item.authors.map { |a| a.respond_to?(:name) ? a.name : a.to_s }
+  elsif item.respond_to?(:content_encoded) && item.content_encoded
+    # Try to extract from HTML content
+    content = item.content_encoded
+    if content =~ /<strong[^>]*>([^<]+)<\/strong>/
+      authors = [$1.strip]
+    end
+  end
+  
+  authors.compact.uniq.first(3) # Max 3 authors
+end


### PR DESCRIPTION
- Create journal configuration with RSS feeds for 11 journals
- Add Ruby script to fetch articles from RSS feeds
- Set up GitHub Actions workflow for daily article updates
- Build responsive Feedly-like display page
- Articles grouped by journal, showing title, authors, and date

The workflow runs daily at 12:00 PM UTC and can be triggered manually.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->